### PR TITLE
WIP: Integrate new API with editor on stories/edit

### DIFF
--- a/components/EditFrame/Nav.js
+++ b/components/EditFrame/Nav.js
@@ -1,0 +1,76 @@
+import React, { Component } from 'react'
+import { Link } from '../../server/routes'
+import { css, merge } from 'glamor'
+import { colors } from '@project-r/styleguide'
+
+const styles = {
+  tab: css({
+    backgroundColor: '#f0f0f0',
+    border: `1px solid ${colors.divider}`,
+    borderRightWidth: 0,
+    bottom: 0,
+    color: '#000',
+    cursor: 'pointer',
+    display: 'inline-block',
+    padding: '10px 20px',
+    textAlign: 'center',
+    textDecoration: 'none',
+    ':hover': {
+      backgroundColor: colors.secondaryBg
+    },
+    ':last-child': {
+      borderRightWidth: '1px'
+    }
+  }),
+  tabSelected: css({
+    backgroundColor: colors.primaryBg
+  })
+}
+
+const menu = {
+  edit: {
+    label: 'Edit',
+    basePath: '/stories/edit/'
+  },
+  meta: {
+    label: 'Meta',
+    basePath: '/stories/meta/'
+  },
+  tree: {
+    label: 'Tree',
+    basePath: '/stories/tree/'
+  },
+  publish: {
+    label: 'Publish',
+    basePath: '/stories/publish/'
+  }
+}
+
+export default class EditorNav extends Component {
+  render () {
+    const { repository, commit } = this.props
+    return (
+      <div style={{ display: 'inline-block' }}>
+        {Object.keys(menu).map((keyName, keyIndex) =>
+          <Link
+            key={keyName}
+            route={
+              menu[keyName].basePath +
+              repository +
+              '/' +
+              (commit ? commit + '/' : '')
+            }
+          >
+            <a
+              {...(this.props.view === keyName
+                ? merge(styles.tab, styles.tabSelected)
+                : styles.tab)}
+            >
+              {menu[keyName].label}
+            </a>
+          </Link>
+        )}
+      </div>
+    )
+  }
+}

--- a/components/EditFrame/index.js
+++ b/components/EditFrame/index.js
@@ -1,0 +1,50 @@
+import React, { Component } from 'react'
+import Nav from './Nav'
+import { css, merge } from 'glamor'
+
+import 'glamor/reset'
+
+import { fontFamilies } from '@project-r/styleguide'
+
+css.global('html', { boxSizing: 'border-box' })
+css.global('*, *:before, *:after', { boxSizing: 'inherit' })
+
+css.global('body', {
+  fontFamily: fontFamilies.sansSerifRegular
+})
+
+const styles = {
+  nav: css({
+    display: 'inline-block',
+    marginBottom: '20px',
+    paddingLeft: '180px'
+  }),
+  main: css({
+    flex: 1,
+    paddingLeft: 0
+  }),
+  // TODO: This is just a simple hook for adjusting the left padding of the
+  // main section for non-edit views for now.
+  spaceLeft: css({
+    paddingLeft: '180px'
+  })
+}
+
+export default class EditorFrame extends Component {
+  render () {
+    const { children, repository, commit, view, spaceLeft } = this.props
+
+    return (
+      <div>
+        <nav {...styles.nav}>
+          <Nav view={view} repository={repository} commit={commit} />
+        </nav>
+        <div
+          {...(spaceLeft ? merge(styles.main, styles.spaceLeft) : styles.main)}
+        >
+          {children}
+        </div>
+      </div>
+    )
+  }
+}

--- a/components/EditSidebar/Checklist.js
+++ b/components/EditSidebar/Checklist.js
@@ -1,0 +1,71 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { css } from 'glamor'
+import { Checkbox } from '@project-r/styleguide'
+import { swissTime } from '../../lib/utils/format'
+
+const timeFormat = swissTime.format('%d. %B %Y, %H:%M Uhr')
+
+const styles = {
+  approvedBy: css({
+    clear: 'left',
+    display: 'block',
+    fontSize: '11px',
+    lineHeight: '1.3em'
+  })
+}
+
+export default class Checklist extends Component {
+  constructor (props) {
+    super(props)
+    this.state = this.getInitialState(this.props)
+  }
+
+  getInitialState (props) {
+    // TODO: Load initial state from backend and persist approvals on change.
+    return this.props.state
+  }
+
+  onChange (keyName, approvals) {
+    this.setState({ approvals: approvals })
+    if (this.props.onChange) {
+      this.props.onChange(keyName, this.state)
+    }
+  }
+
+  render () {
+    return (
+      <div>
+        {Object.keys(this.state.approvals).map((keyName, keyIndex) =>
+          <p key={keyName}>
+            <Checkbox
+              checked={this.state.approvals[keyName].checked}
+              disabled={this.props.disabled}
+              onChange={(_, checked) => {
+                let approvals = this.state.approvals
+                approvals[keyName].checked = checked
+                this.onChange(keyName, approvals)
+              }}
+            >
+              {this.state.approvals[keyName].label}
+              {this.state.approvals[keyName].approvedBy &&
+                <span {...styles.approvedBy}>
+                  {this.state.approvals[keyName].approvedBy}
+                </span>}
+              {this.state.approvals[keyName].approvedDatetime &&
+                <span {...styles.approvedBy}>
+                  {timeFormat(
+                    new Date(this.state.approvals[keyName].approvedDatetime)
+                  )}
+                </span>}
+            </Checkbox>
+          </p>
+        )}
+      </div>
+    )
+  }
+}
+
+Checklist.propTypes = {
+  state: PropTypes.object
+}

--- a/components/EditSidebar/CommitHistory.js
+++ b/components/EditSidebar/CommitHistory.js
@@ -1,0 +1,73 @@
+import React from 'react'
+import { Link } from '../../server/routes'
+import { css } from 'glamor'
+import { swissTime } from '../../lib/utils/format'
+
+import { colors } from '@project-r/styleguide'
+
+const timeFormat = swissTime.format('%d. %B %Y, %H:%M Uhr')
+
+const styles = {
+  commits: css({
+    borderBottom: `1px dotted ${colors.divider}`,
+    borderTop: `1px dotted ${colors.divider}`,
+    listStyleType: 'none',
+    margin: '5px 0 20px',
+    maxHeight: '300px',
+    overflow: 'scroll',
+    padding: 0
+  }),
+  commit: css({
+    borderBottom: `1px solid ${colors.divider}`,
+    fontSize: '13px',
+    padding: '5px 0',
+    position: 'relative'
+  }),
+  date: css({
+    display: 'block',
+    fontSize: '11px'
+  })
+}
+
+const CommitHistory = ({ commits, repository }) => {
+  if (commits.length) {
+    return (
+      <div>
+        <ul {...styles.commits}>
+          {commits.map(commit =>
+            <li key={commit.id} {...styles.commit}>
+              <Link
+                route='editor/edit'
+                params={Object.assign(
+                  {},
+                  {
+                    repository: repository,
+                    commit: commit.id
+                  }
+                )}
+              >
+                <a>
+                  {commit.message}
+                </a>
+              </Link>
+              <span {...styles.date}>
+                {commit.author.email}
+              </span>
+              <span {...styles.date}>
+                {timeFormat(new Date(commit.date))}
+              </span>
+            </li>
+          )}
+        </ul>
+      </div>
+    )
+  } else {
+    return (
+      <div>
+        <i>No commits</i>
+      </div>
+    )
+  }
+}
+
+export default CommitHistory

--- a/components/EditSidebar/index.js
+++ b/components/EditSidebar/index.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { colors } from '@project-r/styleguide'
+import CloseIcon from 'react-icons/lib/md/close'
 
 const panelWidthPx = 180
 const transitionDurationMs = 300
@@ -43,17 +44,6 @@ const styles = {
   })
 }
 
-const CloseIcon = ({ size, fill, style }) =>
-  <svg style={style} fill={fill} height={size} viewBox='0 0 24 24' width={size}>
-    <path d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z' />
-    <path d='M0 0h24v24H0z' fill='none' />
-  </svg>
-
-CloseIcon.defaultProps = {
-  fill: '#000',
-  size: 24
-}
-
 class PseudoModal extends React.Component {
   render () {
     return (
@@ -63,7 +53,7 @@ class PseudoModal extends React.Component {
           {...styles.closeButton}
           title='Close'
         >
-          <CloseIcon />
+          <CloseIcon color='#000' size={24} />
         </a>
         {this.props.children}
       </div>

--- a/components/EditSidebar/index.js
+++ b/components/EditSidebar/index.js
@@ -1,0 +1,127 @@
+import Portal from 'react-portal'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { css } from 'glamor'
+import { colors } from '@project-r/styleguide'
+
+const panelWidthPx = 180
+const transitionDurationMs = 300
+
+const styles = {
+  container: css({
+    position: 'absolute',
+    top: 0,
+    right: '10px'
+  }),
+  toolbar: {
+    backgroundColor: '#fff',
+    borderLeft: `1px solid ${colors.divider}`,
+    borderRadius: '2px 0 0 2px',
+    bottom: 0,
+    width: `${panelWidthPx}px`,
+    opacity: 1,
+    padding: '40px 10px 10px',
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    transition: `right ${transitionDurationMs}ms`,
+    zIndex: 1
+  },
+  closeButton: css({
+    padding: '10px',
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    ':hover': {
+      opacity: 0.6
+    }
+  }),
+  openButton: css({
+    position: 'absolute',
+    right: 0,
+    top: '10px'
+  })
+}
+
+const CloseIcon = ({ size, fill, style }) =>
+  <svg style={style} fill={fill} height={size} viewBox='0 0 24 24' width={size}>
+    <path d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z' />
+    <path d='M0 0h24v24H0z' fill='none' />
+  </svg>
+
+CloseIcon.defaultProps = {
+  fill: '#000',
+  size: 24
+}
+
+class PseudoModal extends React.Component {
+  render () {
+    return (
+      <div {...css(styles.toolbar)}>
+        <a
+          onClick={this.props.closePortal}
+          {...styles.closeButton}
+          title='Close'
+        >
+          <CloseIcon />
+        </a>
+        {this.props.children}
+      </div>
+    )
+  }
+}
+
+PseudoModal.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.element),
+    PropTypes.element
+  ]),
+  closePortal: PropTypes.func
+}
+
+export default class EditSidebar extends Component {
+  constructor (props) {
+    super(props)
+    this.state = this.getInitialState(this.props)
+  }
+
+  getInitialState (props) {
+    return { toolbar: false }
+  }
+
+  render () {
+    const { children } = this.props
+    const openButton = <button {...styles.openButton}>Toolbar</button>
+    return (
+      <div {...styles.container}>
+        <Portal
+          closeOnEsc
+          openByClickOn={openButton}
+          isOpened
+          onOpen={portal => {
+            this.setState({ toolbar: portal.firstChild })
+            portal.firstChild.style.right = '-' + panelWidthPx + 'px'
+            // 0 timeout to trigger a browser reflow and allow for the transition.
+            setTimeout(() => {
+              portal.firstChild.style.right = '0'
+            }, 0)
+          }}
+          beforeClose={(portal, removeFromDom) => {
+            portal.firstChild.style.right = '-' + panelWidthPx + 'px'
+            setTimeout(removeFromDom, transitionDurationMs)
+          }}
+        >
+          <PseudoModal>
+            <div {...css(styles.hoverToolbar)}>
+              {children}
+            </div>
+          </PseudoModal>
+        </Portal>
+      </div>
+    )
+  }
+}
+
+EditSidebar.propTypes = {
+  state: PropTypes.object
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-apollo": "^1.4.15",
     "react-dom": "^15.6.1",
     "react-icons": "^2.2.5",
+    "react-portal": "^3.1.0",
     "redux": "^3.7.2",
     "remark-parse": "^4.0.0",
     "remark-stringify": "^4.0.0",

--- a/pages/editor/edit.js
+++ b/pages/editor/edit.js
@@ -10,9 +10,9 @@ import { css } from 'glamor'
 import { Raw, resetKeyGenerator } from 'slate'
 import { Button, Label } from '@project-r/styleguide'
 
-import App from '../../lib/App'
-import blank from '../../lib/editor/templates/blank.json'
-import Editor from '../../lib/editor/components/Editor'
+import Frame from '../../components/Frame'
+import Editor from '../../components/editor/NewsletterEditor'
+
 import EditFrame from '../../components/EditFrame'
 import EditSidebar from '../../components/EditSidebar'
 import Checklist from '../../components/EditSidebar/Checklist'
@@ -196,7 +196,18 @@ class EditorPage extends Component {
     let committedEditorState
     let commit
     if (view === 'new') {
-      committedEditorState = Raw.deserialize(blank, { terse: true })
+      committedEditorState = Raw.deserialize({
+        nodes: [{
+          kind: 'block',
+          type: 'paragraph',
+          nodes: [
+            {
+              kind: 'text',
+              text: 'Enter your text here...'
+            }
+          ]
+        }]
+      }, { terse: true })
     } else {
       commit = repo.commits.filter(commit => {
         return commit.id === commitId
@@ -385,7 +396,6 @@ class EditorPage extends Component {
   }
 
   render () {
-    console.log(this.props)
     const { repository, commit } = this.props.url.query
     const {
       editorState,
@@ -399,7 +409,7 @@ class EditorPage extends Component {
     }
     if (editorState) {
       return (
-        <App>
+        <Frame raw>
           <EditFrame view={'edit'} repository={repository} commit={commit}>
             {localStorageNotSupported &&
               <div {...css(styles.danger)}>
@@ -449,7 +459,7 @@ class EditorPage extends Component {
               </EditSidebar>
             </div>
           </EditFrame>
-        </App>
+        </Frame>
       )
     } else {
       return (

--- a/pages/editor/edit.js
+++ b/pages/editor/edit.js
@@ -1,41 +1,496 @@
-import React, { Component } from 'react'
-import withData from '../../lib/apollo/withData'
-import { Raw, resetKeyGenerator } from 'slate'
-import App from '../../lib/App'
-import lorem from '../../lib/editor/templates/lorem.json'
-import Editor from '../../lib/editor/components/Editor'
-import EditorFrame from '../../lib/components/EditorFrame'
+// TODO: Make commit mutation work.
+// TODO: Implement subscription to uncommitted changes when new API is ready.
 
-const getInitialState = () => {
-  resetKeyGenerator()
-  return {
-    state: Raw.deserialize(lorem, { terse: true })
+import React, { Component } from 'react'
+import { compose } from 'redux'
+import { Router } from '../../server/routes'
+import withData from '../../lib/apollo/withData'
+import { gql, graphql } from 'react-apollo'
+import { css } from 'glamor'
+import { Raw, resetKeyGenerator } from 'slate'
+import { Button, Label } from '@project-r/styleguide'
+
+import App from '../../lib/App'
+import blank from '../../lib/editor/templates/blank.json'
+import Editor from '../../lib/editor/components/Editor'
+import EditFrame from '../../components/EditFrame'
+import EditSidebar from '../../components/EditSidebar'
+import Checklist from '../../components/EditSidebar/Checklist'
+import CommitHistory from '../../components/EditSidebar/CommitHistory'
+
+import initLocalStore from '../../lib/utils/localStorage'
+
+const query = gql`
+  query repo($repoId: ID!) {
+    repo(id: $repoId) {
+      id
+      commits(page: 1) {
+        id
+        message
+        parentIds
+        date
+        author {
+          email
+        }
+        document {
+          encoding
+          content
+          commit {
+            id
+            message
+          }
+          meta {
+            title
+          }
+        }
+      }
+    }
   }
+`
+const commitMutation = gql`
+  mutation commit(
+    $repoId: ID!
+    $parentId: ID!
+    $message: String!
+    $document: DocumentInput!
+  ) {
+    commit(
+      repoId: $repoId
+      parentId: $parentId
+      message: $message
+      document: $document
+    ) {
+      id
+      parentIds
+      message
+      author {
+        email
+      }
+      date
+      document {
+        encoding
+        content
+        commit {
+          id
+          message
+        }
+        meta {
+          title
+        }
+      }
+    }
+  }
+`
+
+const uncommittedChangesMutation = gql`
+  mutation uncommittedChanges($repoId: ID!, $action: Action!) {
+    uncommittedChanges(repoId: $repoId, action: $action)
+  }
+`
+const defaultChecklistState = {
+  approvals: {
+    cvd1: {
+      label: 'CvD initial',
+      checked: false
+    },
+    ad: {
+      label: 'Art Director',
+      checked: false
+    },
+    korrektur: {
+      label: 'Korrektur',
+      checked: false
+    },
+    cvd2: {
+      label: 'CvD final',
+      checked: false
+    }
+  }
+}
+
+const styles = {
+  uncommittedChanges: {
+    fontSize: '13px',
+    margin: '0 0 20px'
+  },
+  danger: {
+    color: 'red'
+  },
+  button: {
+    height: 40,
+    fontSize: '16px'
+  }
+}
+
+const getLocalStorageKey = (repoId, commitId, view) => {
+  return `${repoId}/${view}/${commitId}`
 }
 
 class EditorPage extends Component {
   constructor (...args) {
     super(...args)
-    this.state = getInitialState()
+
+    this.loadState = this.loadState.bind(this)
+    this.changeHandler = this.changeHandler.bind(this)
+    this.checklistHandler = this.checklistHandler.bind(this)
+    this.commitHandler = this.commitHandler.bind(this)
+    this.documentChangeHandler = this.documentChangeHandler.bind(this)
+    this.revertHandler = this.revertHandler.bind(this)
+
+    this.state = {
+      checklistState: defaultChecklistState,
+      commit: null,
+      committing: false,
+      editorState: null,
+      localStorageNotSupported: false,
+      repo: null,
+      uncommittedChanges: null
+    }
   }
 
-  commitHandler (state, ...args) {
-    this.setState({ state })
+  componentWillReceiveProps (nextProps) {
+    resetKeyGenerator()
+    this.loadState(nextProps)
+  }
+
+  revertHandler (e) {
+    this.store.clear()
+    this.loadState(this.props)
+  }
+
+  loadState (props) {
+    const {
+      data: { loading, error, repo },
+      url,
+      uncommittedChangesMutation
+    } = props
+
+    if (error) {
+      console.log('graphql error:', error)
+    }
+    if (loading) {
+      return
+    }
+    if (!repo) {
+      console.log('Could not load repo')
+      return
+    }
+
+    this.setState({
+      repo: repo
+    })
+
+    let commitId = url.query.commit
+    let view = !commitId ? 'new' : 'edit'
+
+    if (!this.store) {
+      this.store = initLocalStore(getLocalStorageKey(repo.id, commitId, view))
+      if (!this.store.supported) {
+        this.setState({
+          localStorageNotSupported: true
+        })
+      }
+    }
+
+    let committedEditorState
+    let commit
+    if (view === 'new') {
+      committedEditorState = Raw.deserialize(blank, { terse: true })
+    } else {
+      commit = repo.commits.filter(commit => {
+        return commit.id === commitId
+      })[0]
+
+      const json = JSON.parse(commit.document.content)
+      committedEditorState = Raw.deserialize(json, { terse: true })
+
+      this.setState({
+        commit: commit
+      })
+    }
+
+    let localState = this.store.getAll()
+    let localEditorState
+    if (localState && localState.editorState /* && localState.commit */) {
+      try {
+        localEditorState = Raw.deserialize(localState.editorState, {
+          terse: true
+        })
+      } catch (e) {
+        console.log('parsing error', e)
+      }
+    }
+
+    if (localEditorState) {
+      uncommittedChangesMutation({
+        repoId: repo.id,
+        action: 'create'
+      }).catch(error => {
+        console.log('uncommittedChangesMutation error')
+        console.log(error)
+      })
+      this.setState({
+        uncommittedChanges: true,
+        // Do we actually need the commit here?
+        // commit: localState.commit,
+        editorState: localEditorState,
+        committedEditorState
+      })
+    } else {
+      uncommittedChangesMutation({
+        repoId: repo.id,
+        action: 'delete'
+      }).catch(error => {
+        console.log('uncommittedChangesMutation error')
+        console.log(error)
+      })
+      this.setState({
+        uncommittedChanges: false,
+        // Do we actually need the commit here?
+        // commit: commit, // repository.commit,
+        editorState: committedEditorState,
+        committedEditorState
+      })
+    }
+  }
+
+  changeHandler (newEditorState) {
+    this.setState({ editorState: newEditorState })
+  }
+
+  documentChangeHandler (_, newEditorState) {
+    const { data: { repo }, uncommittedChangesMutation } = this.props
+    const { committedEditorState, uncommittedChanges } = this.state
+
+    const serializedNewEditorState = Raw.serialize(newEditorState, {
+      terse: true
+    })
+    const serializedCommittedEditorState = Raw.serialize(committedEditorState, {
+      terse: true
+    })
+    if (
+      JSON.stringify(serializedNewEditorState) !==
+      JSON.stringify(serializedCommittedEditorState)
+    ) {
+      this.store.set('editorState', serializedNewEditorState)
+      // Do we actually need the commit here?
+      // this.store.set('commit', commit) //repository.commit)
+
+      if (!uncommittedChanges) {
+        this.setState({
+          uncommittedChanges: true
+        })
+        uncommittedChangesMutation({
+          repoId: repo.id,
+          action: 'create'
+        }).catch(error => {
+          console.log('uncommittedChangesMutation error')
+          console.log(error)
+        })
+      }
+    } else {
+      if (uncommittedChanges) {
+        this.store.clear()
+        this.setState({
+          uncommittedChanges: false
+        })
+        uncommittedChangesMutation({
+          repoId: repo.id,
+          action: 'delete'
+        }).catch(error => {
+          console.log('uncommittedChangesMutation error')
+          console.log(error)
+        })
+      }
+    }
+  }
+
+  commitHandler () {
+    const {
+      data: { repo },
+      url,
+      view,
+      commitMutation,
+      uncommittedChangesMutation
+    } = this.props
+    const { editorState, commit } = this.state
+
+    const message = window.prompt('Commit message:')
+    if (!message) {
+      return
+    }
+    this.setState({
+      committing: true
+    })
+
+    // TODO: This currently throws an error on the backend:
+    // TypeError: Converting circular structure to JSON.
+    commitMutation({
+      repoId: repo.id,
+      parentId: commit.id,
+      message: message,
+      document: {
+        content: JSON.stringify(
+          Raw.serialize(editorState, { terse: true }),
+          null,
+          2
+        ),
+        encoding: 'UTF-8'
+      }
+    })
+      .then(result => {
+        this.store.clear()
+        uncommittedChangesMutation({
+          repoId: repo.id,
+          action: 'delete'
+        }).catch(error => {
+          console.log('uncommittedChangesMutation error')
+          console.log(error)
+        })
+
+        // TODO: Determine whether autobranching occured and handle branching.
+        let isNewBranch = false
+
+        if (isNewBranch || view === 'new') {
+          setTimeout(() => {
+            Router.pushRoute('stories/edit', {
+              repository: url.query.repository,
+              commit: 'newCommitIDhere' // TODO: Fill in from response.
+            })
+            this.setState({
+              committing: false,
+              uncommittedChanges: false
+            })
+          }, 2000)
+        } else {
+          this.setState({
+            committing: false,
+            uncommittedChanges: false
+          })
+        }
+      })
+      .catch(e => {
+        console.log('commit catched')
+        console.log(e)
+      })
+  }
+
+  checklistHandler (keyName, checklistState) {
+    let checklistItem = checklistState.approvals[keyName]
+    // TODO: Fill this mock data from an actual backend response.
+    checklistItem.approvedBy = checklistItem.checked ? 'John Doe' : null
+    checklistItem.approvedDatetime = checklistItem.checked ? Date.now() : null
+    this.setState({ checklistState: checklistState })
   }
 
   render () {
+    console.log(this.props)
     const { repository, commit } = this.props.url.query
-    return (
-      <App>
-        <EditorFrame view={'edit'} repository={repository} commit={commit}>
-          <Editor
-            state={this.state.state}
-            onChange={this.commitHandler.bind(this)}
-          />
-        </EditorFrame>
-      </App>
-    )
+    const {
+      editorState,
+      committing,
+      uncommittedChanges,
+      localStorageNotSupported
+    } = this.state
+
+    if (committing) {
+      return <div>Commiting...</div>
+    }
+    if (editorState) {
+      return (
+        <App>
+          <EditFrame view={'edit'} repository={repository} commit={commit}>
+            {localStorageNotSupported &&
+              <div {...css(styles.danger)}>
+                LocalStorage not available, your changes can't be saved locally!
+              </div>}
+            <div>
+              <Editor
+                state={this.state.editorState}
+                onChange={this.changeHandler}
+                onDocumentChange={this.documentChangeHandler}
+              />
+              <EditSidebar>
+                <div {...css(styles.uncommittedChanges)}>
+                  {uncommittedChanges &&
+                    <Label>You have uncommitted changes</Label>}
+                  {!uncommittedChanges &&
+                    <Label>All your changes are committed</Label>}
+                  <Button
+                    disabled={!uncommittedChanges}
+                    onClick={this.revertHandler}
+                    style={styles.button}
+                  >
+                    Revert
+                  </Button>
+                  <Button
+                    primary
+                    disabled={!uncommittedChanges}
+                    onClick={this.commitHandler}
+                    style={styles.button}
+                  >
+                    Commit
+                  </Button>
+                </div>
+                <Label>Checklist</Label>
+                <Checklist
+                  disabled={!!uncommittedChanges}
+                  onChange={this.checklistHandler}
+                  state={this.state.checklistState}
+                />
+                <Label>History</Label>
+                <CommitHistory
+                  commits={this.state.repo.commits}
+                  repository={repository}
+                />
+                <Label>Who's working on this?</Label>
+                <p>TODO when API is ready</p>
+              </EditSidebar>
+            </div>
+          </EditFrame>
+        </App>
+      )
+    } else {
+      return (
+        <div>
+          <i>empty</i>
+        </div>
+      )
+    }
   }
 }
 
-export default withData(EditorPage)
+export default compose(
+  withData,
+  graphql(query, {
+    options: ({ url }) => ({
+      variables: {
+        repoId: 'orbiting/' + url.query.repository
+      }
+    })
+  }),
+  graphql(commitMutation, {
+    props: ({ mutate, ownProps: { url } }) => ({
+      commitMutation: variables =>
+        mutate({
+          variables,
+          refetchQueries: [
+            {
+              query,
+              variables: {
+                repoId: 'orbiting/' + url.query.repository
+              }
+            }
+          ]
+        })
+    })
+  }),
+  graphql(uncommittedChangesMutation, {
+    props: ({ mutate }) => ({
+      uncommittedChangesMutation: variables =>
+        mutate({
+          variables
+        })
+    })
+  })
+)(EditorPage)


### PR DESCRIPTION
Most interesting file: pages/editor/edit.js
The new UI components are just renamed/simplified clones of existing /lib components

Not working yet:
- Commit handler (TypeError ...)
- Who's working? subscription (waiting for new API readiness)

Otherwise already pretty much like the github editor:
![bildschirmfoto 2017-08-22 um 14 05 10](https://user-images.githubusercontent.com/23520051/29565055-a9955c0a-8744-11e7-855c-0c9c1e1f980b.png)
![bildschirmfoto 2017-08-22 um 14 05 25](https://user-images.githubusercontent.com/23520051/29565054-a994ee82-8744-11e7-83e5-c238a7056ef9.png)
