### PR TITLE
Md Zones & Cover Serialization

### DIFF
--- a/components/editor/NewsletterEditor.js
+++ b/components/editor/NewsletterEditor.js
@@ -6,7 +6,7 @@ import { css } from 'glamor'
 import { NarrowContainer } from '@project-r/styleguide'
 
 import MarkdownSerializer from '../../lib/serializer'
-import getRules from './utils/getRules'
+import {getSerializationRules} from './utils/getRules'
 
 import styles from './styles'
 import Sidebar from './Sidebar'
@@ -53,7 +53,7 @@ const plugins = [
 ]
 
 export const serializer = new MarkdownSerializer({
-  rules: getRules(plugins)
+  rules: getSerializationRules(plugins)
 })
 
 const textFormatButtons = [

--- a/components/editor/modules/cover/index.js
+++ b/components/editor/modules/cover/index.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { Block } from 'slate'
 import { matchBlock, matchDocument } from '../../utils'
 import { IMAGE } from '../image'
@@ -38,7 +39,18 @@ export const isCover = matchBlock(COVER)
 
 export const cover = {
   match: isCover,
-  render: Cover
+  render: Cover,
+  matchMdast: (node) => node.type === 'zone' && node.identifier === COVER,
+  fromMdast: (node, index, parent, visitChildren) => ({
+    kind: 'block',
+    type: COVER,
+    nodes: visitChildren(node)
+  }),
+  toMdast: (object, index, parent, visitChildren) => ({
+    type: 'zone',
+    identifier: COVER,
+    children: visitChildren(object)
+  })
 }
 
 export {

--- a/components/editor/modules/cover/serializer.test.js
+++ b/components/editor/modules/cover/serializer.test.js
@@ -1,0 +1,26 @@
+import test from 'tape'
+import cover, {COVER} from './'
+import {getSerializationRules} from '../../utils/getRules'
+import MarkdownSerializer from '../../../../lib/serializer'
+
+const serializer = new MarkdownSerializer({
+  rules: getSerializationRules([
+    ...cover.plugins
+  ])
+})
+
+test('cover serialization', assert => {
+  const md = `<section><h6>${COVER}</h6>
+
+
+
+<hr /></section>`
+  const state = serializer.deserialize(md)
+  const node = state.document.nodes.first()
+
+  assert.equal(node.kind, 'block')
+  assert.equal(node.type, COVER)
+
+  assert.equal(serializer.serialize(state).trimRight(), md)
+  assert.end()
+})

--- a/components/editor/utils/getRules.js
+++ b/components/editor/utils/getRules.js
@@ -1,4 +1,9 @@
-export default plugins => plugins.reduce(
+const getRules = plugins => plugins.reduce(
   (all, plugin) => all.concat((plugin.schema || {}).rules).filter(Boolean),
   []
 )
+
+export default getRules
+
+export const getSerializationRules = plugins =>
+  getRules(plugins).filter(r => r.fromMdast || r.toMdast)

--- a/components/editor/utils/getRules.test.js
+++ b/components/editor/utils/getRules.test.js
@@ -1,5 +1,5 @@
 import test from 'tape'
-import getRules from './getRules'
+import getRules, {getSerializationRules} from './getRules'
 
 test('utils.getRules', assert => {
   assert.plan(1)
@@ -20,4 +20,29 @@ test('utils.getRules', assert => {
       }
     }
   ]), ['A', 'B'], 'extract rules from multiple plugins and skip plugins without schema or rules')
+})
+
+test('utils.getSerializationRules', assert => {
+  assert.plan(2)
+  assert.deepEqual(getSerializationRules([
+    {
+      schema: {
+        rules: [
+          'A'
+        ]
+      }
+    }
+  ]), [], 'skip rules without mdast helpers')
+
+  assert.deepEqual(getSerializationRules([
+    {
+      schema: {
+        rules: [
+          'A',
+          {fromMdast: true},
+          {toMdast: true}
+        ]
+      }
+    }
+  ]), [{fromMdast: true}, {toMdast: true}], 'only rules with mdast helpers')
 })

--- a/lib/serializer/index.js
+++ b/lib/serializer/index.js
@@ -77,7 +77,7 @@ class MarkdownSerializer {
             type: 'html',
             value: `<section><h6>${node.identifier}</h6>`
           },
-          Object.keys(node.data).length && {
+          node.data && Object.keys(node.data).length && {
             type: 'code',
             lang: null,
             value: JSON.stringify(node.data, null, 2)

--- a/lib/serializer/index.js
+++ b/lib/serializer/index.js
@@ -4,6 +4,8 @@ const remarkParse = require('remark-parse')
 const { equals } = require('ramda')
 const { Raw } = require('slate')
 
+const zone = require('./zone')
+
 const rootRule = {
   match: object => object.kind === 'document',
   matchMdast: node => node.type === 'root',
@@ -27,18 +29,69 @@ class MarkdownSerializer {
       .concat(options.rules)
       .concat(rootRule)
 
-    this.processor = unified()
+    const parser = unified()
       .use(remarkParse, {
         commonmark: true
       })
+      .use(zone.collapse, {
+        test: ({type, value}) => {
+          if (type !== 'html') {
+            return
+          }
+          if (value.match(/^\s*<section>\s*<h6>([^<]+)<\/h6>/)) {
+            return 'start'
+          }
+          if (value.match(/^\s*<hr\s*\/>\s*<\/section>\s*/)) {
+            return 'end'
+          }
+        },
+        mutate: (start, nodes, end) => {
+          let data = {}
+          const identifier = start.value.match(/<h6>([^<]+)<\/h6>/)[1].trim()
+          const dataNode = nodes[0]
+          const hasDataNode = dataNode && dataNode.type === 'code'
+          if (hasDataNode) {
+            data = JSON.parse(dataNode.value)
+          }
+          return {
+            type: 'zone',
+            identifier,
+            data,
+            children: hasDataNode
+              ? nodes.slice(1)
+              : nodes
+          }
+        }
+      })
+    this.parse = md => parser.runSync(parser.parse(md))
+
+    const stringifier = unified()
       .use(remarkStringify, {
         bullet: '*',
-        fence: '~',
-        fences: true,
-        incrementListMarker: false
+        fences: true
       })
+      .use(zone.expand, {
+        test: ({type}) => type === 'zone',
+        mutate: (node) => [
+          {
+            type: 'html',
+            value: `<section><h6>${node.identifier}</h6>`
+          },
+          Object.keys(node.data).length && {
+            type: 'code',
+            lang: null,
+            value: JSON.stringify(node.data, null, 2)
+          },
+          ...node.children,
+          {
+            type: 'html',
+            value: '<hr /></section>'
+          }
+        ].filter(Boolean)
+      })
+    this.stringify = mdast => stringifier.stringify(stringifier.runSync(mdast))
   }
-  toMdast (raw) {
+  toMdast (state) {
     const visitRanges = (ranges, parent) => {
       if (!ranges.length) {
         return []
@@ -87,7 +140,6 @@ class MarkdownSerializer {
         return children.concat(visit(child, i, object))
       }, [])
     }
-    const stringify = (mdast) => this.processor.stringify(mdast)
     const visit = (object, index, parent, visitChildren) => {
       const rule = this.rules.find(r => r.match(object))
       if (!rule || !rule.toMdast) {
@@ -97,17 +149,18 @@ class MarkdownSerializer {
       const mdastNode = rule.toMdast(
         object, index, parent,
         visitChildren || defaultVisitChildren,
-        stringify
+        this.stringify
       )
 
       return mdastNode
     }
 
+    const raw = Raw.serialize(state).document
     return visit(raw, 0, null)
   }
   serialize (state) {
-    return this.processor.stringify(
-      this.toMdast(Raw.serialize(state).document)
+    return this.stringify(
+      this.toMdast(state)
     )
   }
   fromMdast (mdast) {
@@ -160,7 +213,6 @@ class MarkdownSerializer {
         return nodes.concat(ret)
       }, [])
     }
-    const parse = (md) => this.processor.parse(md)
     const visit = (node, index, parent, visitChildren) => {
       if (node.type === 'text') {
         return {
@@ -184,7 +236,7 @@ class MarkdownSerializer {
       const slateNode = rule.fromMdast(
         node, index, parent,
         visitChildren || defaultVisitChildren,
-        parse
+        this.parse
       )
       if (slateNode.kind === 'mark') {
         return deserializeMark(slateNode)
@@ -192,12 +244,13 @@ class MarkdownSerializer {
       return slateNode
     }
 
-    return visit(mdast, 0, null)
+    const raw = visit(mdast, 0, null)
+    return Raw.deserialize(raw)
   }
   deserialize (md) {
-    return Raw.deserialize(this.fromMdast(
-      this.processor.parse(md)
-    ))
+    return this.fromMdast(
+      this.parse(md)
+    )
   }
 }
 

--- a/lib/serializer/zone.js
+++ b/lib/serializer/zone.js
@@ -1,0 +1,74 @@
+// Inspired by https://github.com/gut-leben-in-deutschland/bericht/blob/master/cabinet/markdown/mdast-zone.js and https://github.com/wooorm/mdast-zone/blob/10ec59489d045535742ce99f6f5692efbccf7038/index.js
+
+module.exports.collapse = ({test, mutate}) => {
+  const collectZones = (parent) => {
+    if (!parent.children || parent.children.length === 0) {
+      return parent
+    }
+
+    const collected = parent.children.reduce((result, child) => {
+      const type = test(child)
+      if (!result.start) {
+        // not in a zone
+        if (type === 'start') {
+          result.start = child
+        }
+      } else if (type === 'end') {
+        // in a zone, remeber end
+        result.end = child
+      }
+      return result
+    }, {})
+
+    if (collected.end) {
+      const children = parent.children
+      const startI = children.indexOf(collected.start)
+      const endI = children.indexOf(collected.end)
+      const zoneChildren = children.slice(startI + 1, endI)
+
+      const zone = mutate(
+        collected.start,
+        zoneChildren,
+        collected.end
+      )
+      // collect nested zones
+      collectZones(zone)
+
+      // replace old children
+      children.splice(
+        startI,
+        endI - startI + 1,
+        zone
+      )
+    } else if (collected.start) {
+      console.error(collected.start)
+      throw Error('zone not ended')
+    }
+
+    return parent
+  }
+
+  return collectZones
+}
+
+module.exports.expand = ({test, mutate}) => {
+  const expandZone = (parent) => {
+    if (!parent.children || parent.children.length === 0) {
+      return parent
+    }
+
+    parent.children = parent.children.reduce(
+      (children, child) => {
+        const expanded = expandZone(child)
+        return children.concat(
+          test(child)
+            ? mutate(expanded)
+            : expanded
+        )
+      },
+      []
+    )
+    return parent
+  }
+  return expandZone
+}

--- a/lib/serializer/zone.test.js
+++ b/lib/serializer/zone.test.js
@@ -1,0 +1,93 @@
+import test from 'tape'
+import MarkdownSerializer from './'
+
+const TYPE = 'Z'
+
+const serializer = new MarkdownSerializer({
+  rules: [
+    {
+      match: object => object.kind === 'block',
+      matchMdast: (node) => node.type === 'zone',
+      fromMdast: (node, index, parent, visitChildren) => ({
+        kind: 'block',
+        type: node.identifier,
+        data: node.data,
+        nodes: visitChildren(node)
+      }),
+      toMdast: (object, index, parent, visitChildren) => ({
+        type: 'zone',
+        identifier: object.type,
+        data: object.data,
+        children: visitChildren(object)
+      })
+    }
+  ]
+})
+
+test('zone serialization', assert => {
+  const md = `<section><h6>${TYPE}</h6>
+
+
+
+<hr /></section>\n`
+  const state = serializer.deserialize(md)
+  const node = state.document.nodes.first()
+
+  assert.equal(node.kind, 'block')
+  assert.equal(node.type, TYPE)
+
+  assert.equal(serializer.serialize(state), md)
+
+  assert.end()
+})
+
+test('zone data serialization', assert => {
+  const md = `<section><h6>WithData</h6>
+
+\`\`\`
+{
+  "KEY": "VALUE"
+}
+\`\`\`
+
+
+
+<hr /></section>\n`
+  const state = serializer.deserialize(md)
+  const node = state.document.nodes.first()
+
+  assert.equal(node.kind, 'block')
+  assert.equal(node.type, 'WithData')
+
+  assert.equal(node.data.get('KEY'), 'VALUE')
+
+  assert.equal(serializer.serialize(state), md)
+
+  assert.end()
+})
+
+test('nested zone serialization', assert => {
+  const md = `<section><h6>A</h6>
+
+<section><h6>AB</h6>
+
+
+
+<hr /></section>
+
+<hr /></section>\n`
+  const state = serializer.deserialize(md)
+  const node = state.document.nodes.first()
+
+  assert.equal(node.kind, 'block')
+  assert.equal(node.type, 'A')
+
+  const zoneB = node.nodes.first()
+
+  assert.equal(zoneB.kind, 'block')
+  assert.equal(zoneB.type, 'AB')
+
+  assert.equal(serializer.serialize(state), md)
+
+  assert.end()
+})


### PR DESCRIPTION
Support markdown zones and use it for covers.

Cover serialization example:
```
<section><h6>COVER</h6>

![This is grey. Not Mr. Grey](/static/example.jpg)

# Hello

> «I am a Lead»

<hr /></section>

Regular P...
```
_(see comment below for how it will look on GH)_

Next step: The cover modules could use it's own serializer instead of `visitChildren`.  Enabling it to spawn a custom type of image. And possibly only allowing certain types.