### PR TITLE
Serializer Delegation

### DIFF
--- a/components/editor/modules/cover/serializer.test.js
+++ b/components/editor/modules/cover/serializer.test.js
@@ -12,7 +12,11 @@ const serializer = new MarkdownSerializer({
 test('cover serialization', assert => {
   const md = `<section><h6>${COVER}</h6>
 
+![Alt](img.jpg)
 
+# Title
+
+> Lead
 
 <hr /></section>`
   const state = serializer.deserialize(md)

--- a/components/editor/modules/headlines/index.js
+++ b/components/editor/modules/headlines/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { css } from 'glamor'
 import Placeholder from '../../Placeholder'
+import MarkdownSerializer from '../../../../lib/serializer'
 
 import { matchBlock } from '../../utils'
 import {
@@ -46,6 +47,12 @@ export const title = {
     </h1>
 }
 
+export const titleSerializer = new MarkdownSerializer({
+  rules: [
+    title
+  ]
+})
+
 export const mediumHeadline = {
   match: matchBlock(MEDIUM_HEADLINE),
   matchMdast: (node) => node.type === 'heading' && node.depth === 2,
@@ -77,6 +84,14 @@ export const smallHeadline = {
   }),
   render: ({ children }) => <h1>{ children }</h1>
 }
+
+export const serializer = new MarkdownSerializer({
+  rules: [
+    title,
+    mediumHeadline,
+    smallHeadline
+  ]
+})
 
 export {
   TITLE,

--- a/components/editor/modules/headlines/serializer.test.js
+++ b/components/editor/modules/headlines/serializer.test.js
@@ -1,25 +1,21 @@
 import test from 'tape'
-import headlines, {
+import {
+  serializer,
+  titleSerializer,
   TITLE,
   MEDIUM_HEADLINE,
   SMALL_HEADLINE
 } from './'
-import getRules from '../../utils/getRules'
-import MarkdownSerializer from '../../../../lib/serializer'
-
-const serializer = new MarkdownSerializer({
-  rules: getRules(headlines.plugins)
-})
 
 test('title serialization', assert => {
-  const state = serializer.deserialize('# Test')
+  const state = titleSerializer.deserialize('# Test')
   const node = state.document.nodes.first()
 
   assert.equal(node.kind, 'block')
   assert.equal(node.type, TITLE)
   assert.equal(node.text, 'Test')
 
-  assert.equal(serializer.serialize(state).trimRight(), '# Test')
+  assert.equal(titleSerializer.serialize(state).trimRight(), '# Test')
   assert.end()
 })
 

--- a/components/editor/modules/image/index.js
+++ b/components/editor/modules/image/index.js
@@ -6,6 +6,8 @@ import styles from '../../styles'
 import { ImageForm, ImageButton } from './ui'
 import { IMAGE } from './constants'
 
+import MarkdownSerializer from '../../../../lib/serializer'
+
 export const ImagePlaceholder = ({ active }) =>
   <div
     style={{ position: 'relative', width: '100%' }}
@@ -41,14 +43,13 @@ export const image = {
       alt: node.alt,
       src: node.url
     },
-    nodes: visitChildren(node)
+    nodes: []
   }),
   toMdast: (object, index, parent, visitChildren) => ({
     type: 'image',
     title: object.data.title,
     alt: object.data.alt,
-    url: object.data.src,
-    children: visitChildren(object)
+    url: object.data.src
   }),
   render: props => {
     const { node, state } = props
@@ -67,6 +68,12 @@ export const image = {
     }
   }
 }
+
+export const serializer = new MarkdownSerializer({
+  rules: [
+    image
+  ]
+})
 
 export {
   IMAGE,

--- a/components/editor/modules/image/serializer.test.js
+++ b/components/editor/modules/image/serializer.test.js
@@ -1,14 +1,23 @@
 import test from 'tape'
 import img, {IMAGE} from './'
-import paragraph, {PARAGRAPH} from '../paragraph'
+import {PARAGRAPH} from '../paragraph'
 import getRules from '../../utils/getRules'
 import MarkdownSerializer from '../../../../lib/serializer'
 
 const serializer = new MarkdownSerializer({
-  rules: getRules([
-    ...img.plugins,
-    ...paragraph.plugins
-  ])
+  rules: getRules(img.plugins).concat({
+    match: (object) => object.kind === 'block' && object.type === PARAGRAPH,
+    matchMdast: (node) => node.type === 'paragraph',
+    fromMdast: (node, index, parent, visitChildren) => ({
+      kind: 'block',
+      type: PARAGRAPH,
+      nodes: visitChildren(node)
+    }),
+    toMdast: (object, index, parent, visitChildren) => ({
+      type: 'paragraph',
+      children: visitChildren(object)
+    })
+  })
 })
 
 test('image serialization', assert => {

--- a/components/editor/modules/lead/index.js
+++ b/components/editor/modules/lead/index.js
@@ -5,6 +5,8 @@ import Placeholder from '../../Placeholder'
 import { matchBlock } from '../../utils'
 import { LEAD } from './constants'
 // import { mq } from '../../styles'
+import MarkdownSerializer from '../../../../lib/serializer'
+import {serializer as paragraphSerializer, PARAGRAPH} from '../paragraph'
 
 export const styles = {
   lead: {
@@ -28,15 +30,18 @@ export const lead = {
   fromMdast: (node, index, parent, visitChildren) => ({
     kind: 'block',
     type: LEAD,
-    nodes: visitChildren(node.children[0])
+    nodes: node.children.length
+      ? paragraphSerializer.fromMdast(node.children[0]).nodes
+      : []
   }),
   toMdast: (object, index, parent, visitChildren) => ({
     type: 'blockquote',
     children: [
-      {
-        type: 'paragraph',
-        children: visitChildren(object)
-      }
+      paragraphSerializer.toMdast({
+        kind: 'block',
+        type: PARAGRAPH,
+        nodes: object.nodes
+      })
     ]
   }),
   render: ({ children, ...props }) =>
@@ -50,6 +55,12 @@ export const lead = {
       {children}
     </p>
 }
+
+export const serializer = new MarkdownSerializer({
+  rules: [
+    lead
+  ]
+})
 
 export {
   LEAD,

--- a/components/editor/modules/lead/serializer.test.js
+++ b/components/editor/modules/lead/serializer.test.js
@@ -1,20 +1,14 @@
 import test from 'tape'
-import lead, {LEAD} from './'
-import getRules from '../../utils/getRules'
-import MarkdownSerializer from '../../../../lib/serializer'
-
-const serializer = new MarkdownSerializer({
-  rules: getRules(lead.plugins)
-})
+import {serializer, LEAD} from './'
 
 test('lead serialization', assert => {
-  const state = serializer.deserialize('> Test')
+  const state = serializer.deserialize('> A **test**')
   const node = state.document.nodes.first()
 
   assert.equal(node.kind, 'block')
   assert.equal(node.type, LEAD)
-  assert.equal(node.text, 'Test')
+  assert.equal(node.text, 'A test')
 
-  assert.equal(serializer.serialize(state).trimRight(), '> Test')
+  assert.equal(serializer.serialize(state).trimRight(), '> A **test**')
   assert.end()
 })

--- a/components/editor/modules/marks/serializer.test.js
+++ b/components/editor/modules/marks/serializer.test.js
@@ -1,15 +1,6 @@
 import test from 'tape'
-import marks, {BOLD, ITALIC} from './'
-import paragraph, {PARAGRAPH} from '../paragraph'
-import getRules from '../../utils/getRules'
-import MarkdownSerializer from '../../../../lib/serializer'
-
-const serializer = new MarkdownSerializer({
-  rules: getRules([
-    ...marks.plugins,
-    ...paragraph.plugins
-  ])
-})
+import {BOLD, ITALIC} from './'
+import {serializer, PARAGRAPH} from '../paragraph'
 
 test('marks serialization', assert => {
   const state = serializer.deserialize('**bold** _italic_ ~~strikethrough~~')

--- a/components/editor/modules/paragraph/index.js
+++ b/components/editor/modules/paragraph/index.js
@@ -3,6 +3,11 @@ import { css } from 'glamor'
 import { ParagraphButton } from './ui'
 import { matchBlock } from '../../utils'
 import { PARAGRAPH } from './constants'
+import MarkdownSerializer from '../../../../lib/serializer'
+import {getSerializationRules} from '../../utils/getRules'
+
+import marks from '../marks'
+import link from '../link'
 
 export const styles = {
   paragraph: {
@@ -27,6 +32,15 @@ export const paragraph = {
   }),
   render: ({ children }) => <p {...css(styles.paragraph)}>{ children }</p>
 }
+
+export const serializer = new MarkdownSerializer({
+  rules: [
+    paragraph
+  ].concat(getSerializationRules([
+    ...marks.plugins,
+    ...link.plugins
+  ]))
+})
 
 export {
   PARAGRAPH,

--- a/lib/serializer/index.js
+++ b/lib/serializer/index.js
@@ -91,7 +91,7 @@ class MarkdownSerializer {
       })
     this.stringify = mdast => stringifier.stringify(stringifier.runSync(mdast))
   }
-  toMdast (state) {
+  toMdast (rawNode, context = {}) {
     const visitRanges = (ranges, parent) => {
       if (!ranges.length) {
         return []
@@ -149,22 +149,22 @@ class MarkdownSerializer {
       const mdastNode = rule.toMdast(
         object, index, parent,
         visitChildren || defaultVisitChildren,
-        this.stringify
+        context
       )
 
       return mdastNode
     }
 
-    const raw = Raw.serialize(state).document
-    return visit(raw, 0, null)
+    return visit(rawNode, 0, null)
   }
   serialize (state, options = {}) {
-    const mdast = this.toMdast(state)
+    const raw = Raw.serialize(state).document
+    const mdast = this.toMdast(raw, options.context)
     return options.mdast
       ? mdast
       : this.stringify(mdast)
   }
-  fromMdast (mdast) {
+  fromMdast (mdast, context = {}) {
     const compactText = (nodes) => {
       return nodes.reduce(
         (compact, node) => {
@@ -237,7 +237,7 @@ class MarkdownSerializer {
       const slateNode = rule.fromMdast(
         node, index, parent,
         visitChildren || defaultVisitChildren,
-        this.parse
+        context
       )
       if (slateNode.kind === 'mark') {
         return deserializeMark(slateNode)
@@ -245,15 +245,15 @@ class MarkdownSerializer {
       return slateNode
     }
 
-    const raw = visit(mdast, 0, null)
-    return Raw.deserialize(raw)
+    return visit(mdast, 0, null)
   }
   deserialize (data, options = {}) {
-    return this.fromMdast(
+    return Raw.deserialize(this.fromMdast(
       options.mdast
         ? data
-        : this.parse(data)
-    )
+        : this.parse(data),
+      options.context
+    ))
   }
 }
 


### PR DESCRIPTION
Skip `visitChildren` and use `fromMdast`/`toMdast` from a serializer of your choosing.

This implied that pretty much all blocks will have their own serializer. See paragraph for a block that allows for inline nodes and marks.