### PR TITLE
Sidebar: Display the initially loaded base commit

### DIFF
--- a/components/EditSidebar/BaseCommit.js
+++ b/components/EditSidebar/BaseCommit.js
@@ -1,0 +1,72 @@
+import React, { Component } from 'react'
+import { gql, graphql } from 'react-apollo'
+import { css } from 'glamor'
+import { Label } from '@project-r/styleguide'
+import { compose } from 'redux'
+import { swissTime } from '../../lib/utils/format'
+import Loader from '../../components/Loader'
+import withT from '../../lib/withT'
+
+const timeFormat = swissTime.format('%d. %B %Y, %H:%M Uhr')
+
+const styles = {
+  container: css({
+    fontSize: '11px',
+    padding: '0 0 5px 0'
+  })
+}
+
+const query = gql`
+  query test($repoId: ID!, $commitId: ID!) {
+    repo(id: $repoId) {
+      id
+      commit(id: $commitId) {
+        id
+        date
+        message
+        author {
+          name
+        }
+      }
+    }
+  }
+`
+
+class BaseCommit extends Component {
+  render () {
+    const { data: {loading, error, repo}, t } = this.props
+    const commit = repo && repo.commit
+
+    return (
+      <Loader loading={loading} error={error} render={() => (
+        <div {...styles.container}>
+          {commit &&
+            <div>
+              <Label>{t('baseCommit/title')}</Label>
+              <div{...styles.title}>
+                {commit.message}
+              </div>
+              <div>
+                {commit.author.name}
+              </div>
+              <div>
+                {timeFormat(new Date(repo.commit.date))}
+              </div>
+            </div>}
+        </div>
+      )} />
+    )
+  }
+}
+
+export default compose(
+  withT,
+  graphql(query, {
+    options: props => ({
+      variables: {
+        repoId: props.repoId,
+        commitId: props.commitId
+      }
+    })
+  })
+)(BaseCommit)

--- a/components/EditSidebar/BaseCommit.js
+++ b/components/EditSidebar/BaseCommit.js
@@ -16,7 +16,7 @@ const styles = {
   })
 }
 
-const query = gql`
+const getCommitInfo = gql`
   query test($repoId: ID!, $commitId: ID!) {
     repo(id: $repoId) {
       id
@@ -61,7 +61,7 @@ class BaseCommit extends Component {
 
 export default compose(
   withT,
-  graphql(query, {
+  graphql(getCommitInfo, {
     options: props => ({
       variables: {
         repoId: props.repoId,

--- a/components/EditSidebar/CommitHistory.js
+++ b/components/EditSidebar/CommitHistory.js
@@ -30,7 +30,7 @@ const styles = {
   })
 }
 
-const CommitHistory = ({ commits, repoId, maxItems, t }) => {
+const CommitHistory = ({ commits, repoId, commitId, maxItems, t }) => {
   const numItems = maxItems || 3
   const repoPath = repoId.split('/')
   if (commits.length) {
@@ -39,17 +39,19 @@ const CommitHistory = ({ commits, repoId, maxItems, t }) => {
         <ul {...styles.commits}>
           {commits.slice(0, numItems).map(commit =>
             <li key={commit.id} {...styles.commit}>
-              <Link
-                route='repo/edit'
-                params={{
-                  repoId: repoPath,
-                  commitId: commit.id
-                }}
-              >
-                <a {...linkRule}>
-                  {commit.message}
-                </a>
-              </Link>
+              {commit.id !== commitId
+                ? <Link
+                  route='repo/edit'
+                  params={{
+                    repoId: repoPath,
+                    commitId: commit.id
+                  }}
+                >
+                  <a {...linkRule}>
+                    {commit.message}
+                  </a>
+                </Link>
+              : <span>{commit.message}</span>}
               <span {...styles.date}>
                 {commit.author.name}
               </span>

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2017-09-22T10:26:13.283Z",
+  "updated": "2017-09-25T14:07:36.395Z",
   "title": "live",
   "data": [
     {
@@ -69,6 +69,10 @@
     {
       "key": "repo/list/add/submit",
       "value": "erstellen"
+    },
+    {
+      "key": "baseCommit/title",
+      "value": "Ausgangsversion"
     },
     {
       "key": "checklist/title",
@@ -220,11 +224,11 @@
     },
     {
       "key": "commit/status/committed",
-      "value": "Alle deine Änderungen sind committed"
+      "value": "Keine Änderungen"
     },
     {
       "key": "commit/status/uncommitted",
-      "value": "Änderungen sind nicht committed"
+      "value": "Änderungen committen?"
     },
     {
       "key": "commit/warn/noStorage",

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -428,6 +428,7 @@ class EditorPage extends Component {
                   <CommitHistory
                     commits={repo.commits}
                     repoId={repoId}
+                    commitId={commitId}
                   />
                 </div>
               )}

--- a/pages/repo/edit.js
+++ b/pages/repo/edit.js
@@ -13,6 +13,7 @@ import Editor, { serializer, newDocument } from '../../components/editor/Newslet
 
 import EditSidebar from '../../components/EditSidebar'
 import Loader from '../../components/Loader'
+import BaseCommit from '../../components/EditSidebar/BaseCommit'
 import Checklist from '../../components/EditSidebar/Checklist'
 import CommitHistory from '../../components/EditSidebar/CommitHistory'
 import UncommittedChanges from '../../components/EditSidebar/UncommittedChanges'
@@ -378,7 +379,10 @@ class EditorPage extends Component {
                   {message}
                 </div>
               ))}
-
+              <BaseCommit
+                repoId={repoId}
+                commitId={commitId}
+              />
               <div {...css(styles.uncommittedChanges)}>
                 <div style={{marginBottom: 10}}>
                   <Label style={{fontSize: 12}}>


### PR DESCRIPTION
Also simplifies the committed/uncommitted messages.

No changes:
![bildschirmfoto 2017-09-25 um 16 13 31](https://user-images.githubusercontent.com/23520051/30813453-c5190cd6-a20d-11e7-8577-86faca356173.png)

With changes:
![bildschirmfoto 2017-09-25 um 16 13 42](https://user-images.githubusercontent.com/23520051/30813473-d121fb96-a20d-11e7-9240-c2b3fee0774e.png)

